### PR TITLE
Theme.AppCompat.DayNight継承からTheme.MaterialComponens.DayNight継承へ変更

### DIFF
--- a/DarkModeSample/app/build.gradle
+++ b/DarkModeSample/app/build.gradle
@@ -24,11 +24,14 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.core:core-ktx:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+
+    // Material Component
+    implementation 'com.google.android.material:material:1.2.0-alpha02'
 }

--- a/DarkModeSample/app/src/main/res/values/themes.xml
+++ b/DarkModeSample/app/src/main/res/values/themes.xml
@@ -6,7 +6,7 @@
     <style name="AppTheme.DayNight" parent="Base.AppTheme" />
 
     <!--Baseがないとビルドエラーになるよ = Duplicate resources-->
-    <style name="Base.AppTheme" parent="Theme.AppCompat.DayNight">
+    <style name="Base.AppTheme" parent="Theme.MaterialComponents.DayNight">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:background">@color/colorBackground</item>


### PR DESCRIPTION
## 変化
Dayのステータスバーの色が変わったくらい
Nightは変更なし(若干アップバーのテキストカラーが暗くなった??)

## スクショ

|テーマ|Theme.AppCompat.DayNight|Theme.MaterialComponens.DayNight|
|---|---|---|
|Day|![Screenshot_1574864370](https://user-images.githubusercontent.com/11660859/69731351-1898dc80-116d-11ea-877f-bbe158e384e8.png)|![Screenshot_1574864422](https://user-images.githubusercontent.com/11660859/69731443-441bc700-116d-11ea-9e25-32ad75a43e6d.png)|
|Night|![Screenshot_1574864383](https://user-images.githubusercontent.com/11660859/69731409-35351480-116d-11ea-96c6-84bc2e98ed04.png)|![Screenshot_1574864412](https://user-images.githubusercontent.com/11660859/69731398-2f3f3380-116d-11ea-8111-b2f91477444b.png)|



