### PR TITLE
ActionBarのテキストの色が変わらない

### DIFF
--- a/DarkModeSample/app/src/main/res/values-night/themes.xml
+++ b/DarkModeSample/app/src/main/res/values-night/themes.xml
@@ -4,6 +4,5 @@
     <style name="AppTheme.DayNight" parent="Base.AppTheme">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:background">@color/colorBackground</item>
     </style>
 </resources>

--- a/DarkModeSample/app/src/main/res/values/styles.xml
+++ b/DarkModeSample/app/src/main/res/values/styles.xml
@@ -1,11 +1,19 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.DayNight">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="actionBarStyle">@style/AppTheme.ActionBarStyle</item>
     </style>
 
+    <style name="AppTheme.ActionBarStyle" parent="@android:style/Widget.Holo.Light.ActionBar">
+        <item name="android:titleTextStyle">@style/AppTheme.ActionBar.TitleTextStyle</item>
+    </style>
+
+    <style name="AppTheme.ActionBar.TitleTextStyle" parent="@android:style/TextAppearance.Holo.Widget.ActionBar.Title">
+        <item name="android:textColor">@android:color/holo_orange_light</item>
+    </style>
 </resources>

--- a/DarkModeSample/app/src/main/res/values/themes.xml
+++ b/DarkModeSample/app/src/main/res/values/themes.xml
@@ -9,6 +9,5 @@
     <style name="Base.AppTheme" parent="Theme.MaterialComponents.DayNight">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:background">@color/colorBackground</item>
     </style>
 </resources>


### PR DESCRIPTION
この方法ではAppBarのタイトルの色が変化しないので、ToolBarを自分で設定するのが良さそう。
参考:https://stackoverflow.com/questions/5861661/actionbar-text-color


```
<style name="AppTheme.ActionBarStyle" parent="@android:style/Widget.Holo.Light.ActionBar">
        <item name="android:titleTextStyle">@style/AppTheme.ActionBar.TitleTextStyle</item>
    </style>

    <style name="AppTheme.ActionBar.TitleTextStyle" parent="@android:style/TextAppearance.Holo.Widget.ActionBar.Title">
        <item name="android:textColor">@android:color/holo_orange_light</item>
    </style>
```